### PR TITLE
Adding parameter to disable gpg_check

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -40,6 +40,7 @@
       yum:
         name: ['xorg-x11-server-Xvfb', 'firefox']
         state: present
+        disable_gpg_check: True
 
     - name: Create temp directory for geckodriver
       tempfile:


### PR DESCRIPTION
Adding additional parameter to disable gpg_check while installing required packages . This check is required to be disabled as it is failing for Rhel 9.2 (RHOS-17.1) recently and breaking plugin on Jenkins due to the "Failed to validate GPG signature for fdk-aac-2.0.0-3.el8.x86_64". Disabling  this parameter doesn't affect package installation/plugin.