### PR TITLE
Fix to handle Volume type

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
+++ b/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
@@ -30,6 +30,14 @@
     openstack network list --external -f json | grep -Po '"Name": *"\K[^"]*'
   register: network_name
 
+- name: Get Volume type name
+  become: true
+  become_user: stack
+  shell: |
+    source /home/stack/overcloudrc
+    openstack volume type list -f json | grep -Po '"Name": *"\K[^"]*'
+  register: volume_type
+
 - name: Create conf file from template
   template:
     src: templates/local-horizon.conf.j2

--- a/roles/infrared-horizon-selenium/templates/local-horizon.conf.j2
+++ b/roles/infrared-horizon-selenium/templates/local-horizon.conf.j2
@@ -12,4 +12,6 @@ external_network = {{ network_name.stdout }}
 [launch_instance]
 image_name = cirros-0.5.2-x86_64-disk.img (15.5 MB)
 [volume]
-volume_type=tripleo
+volume_type = {{volume_type.stdout}}
+[selenium]
+message_implicit_wait=0.5


### PR DESCRIPTION
In unified jenkins job we get volume type as "tripleo_default" and in usual deployment we get it as "tripleo" by default . This change here will make sure the correct volume type name is fetched . Also increased wait time .