### PR TITLE
Fix config file to pick only tripleo incase of multiple volume type

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
+++ b/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
@@ -35,7 +35,7 @@
   become_user: stack
   shell: |
     source /home/stack/overcloudrc
-    openstack volume type list -f json | grep tripleo | grep -Po '"Name": *"\K[^"]*'
+    openstack volume type list -c Name -f value | grep tripleo
   register: volume_type
 
 - name: Create conf file from template

--- a/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
+++ b/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
@@ -35,7 +35,7 @@
   become_user: stack
   shell: |
     source /home/stack/overcloudrc
-    openstack volume type list -f json | grep -Po '"Name": *"\K[^"]*'
+    openstack volume type list -f json | grep tripleo | grep -Po '"Name": *"\K[^"]*'
   register: volume_type
 
 - name: Create conf file from template


### PR DESCRIPTION
Recently seen in Unified job as storage tempest test case are creating new volume type other than the one created as part of deployment (tripleo / tripleo_default) which ends up confusing the plugin while selecting the volume type . This minor fix will make sure only tripleo/tripleo_default volume type gets picked up by config file 