### PR TITLE
Change report file name(s)

### DIFF
--- a/roles/infrared-horizon-selenium/scripts/runtests
+++ b/roles/infrared-horizon-selenium/scripts/runtests
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 . .venv/bin/activate
-PATH=$PATH:/usr/local/bin/ INTEGRATION_TESTS=1 SELENIUM_HEADLESS=1 pytest openstack_dashboard/test/integration_tests --ds=openstack_dashboard.test.settings -v --junitxml="test_reports/integration_test_results.xml" --html="test_reports/integration_test_results.html" --self-contained-html
+PATH=$PATH:/usr/local/bin/ INTEGRATION_TESTS=1 SELENIUM_HEADLESS=1 pytest openstack_dashboard/test/integration_tests --ds=openstack_dashboard.test.settings -v --junitxml="test_reports/ui_integration_test_results.xml" --html="test_reports/ui_integration_test_results.html" --self-contained-html
 

--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -188,14 +188,14 @@
 
     - name: Fetch JUnit XML results file
       fetch:
-        src: "{{ selenium_tests_temp.path }}/test_reports/integration_test_results.xml"
-        dest: "{{ inventory_dir }}/test_results/integration_test_results.xml"
+        src: "{{ selenium_tests_temp.path }}/test_reports/ui_integration_test_results.xml"
+        dest: "{{ inventory_dir }}/test_results/ui_integration_test_results.xml"
         flat: yes
         fail_on_missing: yes
 
     - name: Fetch HTML results file
       fetch:
-        src: "{{ selenium_tests_temp.path }}/test_reports/integration_test_results.html"
-        dest: "{{ inventory_dir }}/test_results/integration_test_results.html"
+        src: "{{ selenium_tests_temp.path }}/test_reports/ui_integration_test_results.html"
+        dest: "{{ inventory_dir }}/test_results/ui_integration_test_results.html"
         flat: yes
         fail_on_missing: no


### PR DESCRIPTION
Hi , 
As per suggestion of consolidation folks , adding prefix UI to integration_test_results.xx file for ease of use when different test files are present in test results artifacts of unified job in jenkins . Changing it at all places in the plugin so that there are no conflicts . 