### PR TITLE
create internal network and add router interface

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -81,7 +81,8 @@
         cloud: overcloud
         state: present
         name: internal
-
+        shared: true
+        
     - name: Create sub-internal subnet
       os_subnet:
         cloud: overcloud
@@ -188,7 +189,19 @@
         cloud: overcloud
         state: absent
         name: horizontest
- 
+        
+    - name: Remove Router
+      os_router:
+        cloud: overcloud
+        state: absent
+        name: router1
+
+    - name: Remove internal network
+      os_network:
+        cloud: overcloud
+        state: absent
+        name: internal    
+        
     - name: Uninstall EPEL and rpmfusion repositories
       become: true
       become_user: root

--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -76,12 +76,28 @@
       include_tasks: configure_selenium_config.yml
       when: selenium_tests_temp.path is defined
 
-    - name: Configure External network to be shared
-      become: true
-      become_user: stack
-      shell: |
-        source /home/stack/overcloudrc
-        openstack network set --share {{ network_name.stdout }}
+    - name: Create internal network
+      os_network:
+        cloud: overcloud
+        state: present
+        name: internal
+
+    - name: Create sub-internal subnet
+      os_subnet:
+        cloud: overcloud
+        state: present
+        network_name: internal
+        name: sub-internal
+        cidr: "172.0.0.1/24"
+
+    - name: Create a router
+      os_router:
+        cloud: overcloud
+        state: present
+        name: router1
+        network: public
+        interfaces:
+        - sub-internal
 
     - name: Remove old project
       os_project:
@@ -160,13 +176,6 @@
       file:
         path: "{{ inventory_dir }}/test_results/"
         state: directory
-
-    - name: Configure External network back to no share
-      become: true
-      become_user: stack
-      shell: |
-        source /home/stack/overcloudrc
-        openstack network set --no-share {{ network_name.stdout }}
 
     - name: Remove old project
       os_project:


### PR DESCRIPTION
this pull requests add the code to 
1 ) create internal network and the subnet for the same .
2 )  Also add the router and create an interface for the internal network subnet 
3 ) removing external network share / no-share code as we would be using internal network for VM creation going forward for ease of use with consolidation jobs 