### PR TITLE
Add code to get backend name

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
+++ b/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
@@ -38,6 +38,14 @@
     openstack volume type list -c Name -f value | grep tripleo
   register: volume_type
 
+- name: Get backend deployment name
+  become: true
+  become_user: stack
+  shell: |
+    source /home/stack/overcloudrc
+    openstack volume service list -c Host -f value | grep hostgroup
+  register: backend_name
+
 - name: Create conf file from template
   template:
     src: templates/local-horizon.conf.j2


### PR DESCRIPTION
We have specific test that fails for certain backend type used during deployment , we can use this parameter to let specific tests run for specific backends