### PR TITLE
pin dependencies to use urllib3<2

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/run_selenium_tests.yml
+++ b/roles/infrared-horizon-selenium/tasks/run_selenium_tests.yml
@@ -18,6 +18,7 @@
       - testtools
       - xvfbwrapper
       - junit2html
+      - urllib3<2  
     chdir: "{{ selenium_tests_temp.path  }}"
     virtualenv: .venv
 


### PR DESCRIPTION
Tests cases failures which are caused by the latest release of requests (released last week)  which has added support for  urllib3 2.0 , urllib3 2.0  does not seem to be compatible with selenium version we are using in our test environment, so I have pinned urllib3<2 to be used 