### PR TITLE
Fix Image error II - increase of robustness.

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -117,7 +117,7 @@
       become_user: stack
       shell: |
         source /home/stack/overcloudrc
-        openstack image list -c Name -f value | paste -s
+        openstack image list -c ID -f value | paste -s
       register: images
 
     - name: Create list of images


### PR DESCRIPTION
ID should be more robustness solution than Name. Because the Name may contain "/t".