### PR TITLE
Add implemenation for CA Certificate

### DIFF
--- a/plugin.spec
+++ b/plugin.spec
@@ -34,4 +34,13 @@ subparsers:
                       help: |
                           The location of the horizon.conf file to be used
                       default: "openstack_dashboard/test/integration_tests/local-horizon.conf"
-     
+
+                  tls-ca:
+                      type: Value
+                      help: |
+                          Specifies the custom CA public key. Might be URL or a link to local file.
+                          Might be several certificates provided, separated with coma
+                          Example:
+                                --tls-ca=https://foo.com/ca.pem,http://bar.org/cert.pem
+                                --tls-ca=/foo/bar/ca.pem
+                      default: ''

--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Run the Selenium Infrared plugin and fetch report files
-    block:
+  block:
     - name: Fetch osp version
       become: true
       become_user: root

--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -1,12 +1,14 @@
 - name: Run the Selenium Infrared plugin and fetch report files
-  become: true
-  become_user: root
-  block:
+    block:
     - name: Fetch osp version
+      become: true
+      become_user: root
       shell: cat /home/stack/core_puddle_version | awk -F "-" '{print $2}'
       register: osp_release
 
     - name: Fetch OSP build number
+      become: true
+      become_user: root
       shell: cat /home/stack/core_puddle_version
       register: osp_build
 
@@ -29,16 +31,22 @@
       tags: rhos-release
 
     - name: Install EPEL repository
+      become: true
+      become_user: root
       shell: |
         sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         sudo rpm -ql epel-release
 
     - name: Install rpmfusion repository
+      become: true
+      become_user: root
       shell: |
         sudo dnf -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
         sudo dnf -y install --nogpgcheck https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 
     - name: Install required packages
+      become: true
+      become_user: root
       yum:
         name: ['xorg-x11-server-Xvfb', 'firefox']
         state: present
@@ -57,6 +65,8 @@
       when: geckodriver_temp.path is defined
 
     - name: Extract the geckodriver
+      become: true
+      become_user: root
       unarchive:
         src: "{{ geckodriver_temp.path }}/geckodriver.tar.gz"
         dest: "/usr/local/bin"
@@ -113,6 +123,7 @@
         name: horizontest
 
     - name: Find all images
+      become: true
       become_user: stack
       shell: |
         source /home/stack/overcloudrc
@@ -167,6 +178,7 @@
         is_public: yes
 
     - name: Download cirros image
+      become: true
       become_user: stack
       get_url:
         url: http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img

--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -13,6 +13,16 @@
       register: osp_build
 
 # TODO build can be "latest" if we want to use in gates
+
+    - name: Install custom CA if needed
+      include_role:
+        name: tls-ca
+      vars:
+        tlsca: "{{ test.tls.ca }}"
+        ansible_become: true
+        ansible_become_user: root
+      when: test.tls.ca != ''
+
     - include_role:
         name: rhos-release
       vars:

--- a/roles/infrared-horizon-selenium/tasks/main.yml
+++ b/roles/infrared-horizon-selenium/tasks/main.yml
@@ -1,18 +1,24 @@
 - name: Run the Selenium Infrared plugin and fetch report files
+  become: true
+  become_user: root
   block:
     - name: Fetch osp version
-      become: true
-      become_user: root
       shell: cat /home/stack/core_puddle_version | awk -F "-" '{print $2}'
       register: osp_release
 
     - name: Fetch OSP build number
-      become: true
-      become_user: root
       shell: cat /home/stack/core_puddle_version
       register: osp_build
 
 # TODO build can be "latest" if we want to use in gates
+
+    - name: Install custom CA if needed
+      include_role:
+        name: tls-ca
+      vars:
+        tlsca: "{{ test.tls.ca }}"
+      when: test.tls.ca != ''
+
     - include_role:
         name: rhos-release
       vars:
@@ -21,22 +27,16 @@
       tags: rhos-release
 
     - name: Install EPEL repository
-      become: true
-      become_user: root
       shell: |
         sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         sudo rpm -ql epel-release
 
     - name: Install rpmfusion repository
-      become: true
-      become_user: root
       shell: |
         sudo dnf -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
         sudo dnf -y install --nogpgcheck https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 
     - name: Install required packages
-      become: true
-      become_user: root
       yum:
         name: ['xorg-x11-server-Xvfb', 'firefox']
         state: present
@@ -55,8 +55,6 @@
       when: geckodriver_temp.path is defined
 
     - name: Extract the geckodriver
-      become: true
-      become_user: root
       unarchive:
         src: "{{ geckodriver_temp.path }}/geckodriver.tar.gz"
         dest: "/usr/local/bin"
@@ -113,7 +111,6 @@
         name: horizontest
 
     - name: Find all images
-      become: true
       become_user: stack
       shell: |
         source /home/stack/overcloudrc
@@ -168,7 +165,6 @@
         is_public: yes
 
     - name: Download cirros image
-      become: true
       become_user: stack
       get_url:
         url: http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img


### PR DESCRIPTION
This pull request add the implementation for CA Certificate role required which gives user an option to inject certs in case of TLS/FIPS enabled deployment setup (if not already present after undercloud installation ).