### PR TITLE
Update configure_selenium_config.yml to incorporate latest changes related to ceph-native job 

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
+++ b/roles/infrared-horizon-selenium/tasks/configure_selenium_config.yml
@@ -43,7 +43,7 @@
   become_user: stack
   shell: |
     source /home/stack/overcloudrc
-    openstack volume service list -c Host -f value | grep hostgroup
+    openstack volume service list -c Host -f value | grep hostgroup | head -n 1
   register: backend_name
 
 - name: Create conf file from template


### PR DESCRIPTION
tracked in this ticket here https://issues.redhat.com/browse/OSPRH-1518 , Ceph-native now deploy mutiple ceph cinder backend , which was causing the job to fail as result did not get parsed properly .

> (overcloud) [stack@undercloud-0 ~]$ openstack volume service list -c Host -f value | grep hostgroup
hostgroup@tripleo_ceph
hostgroup@tripleo_ceph_cinderfast

This change will fetch only one result which is enough for us for get the backend name and skip/run the test case based on it 