### PR TITLE
Fix Django version dependency

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/run_selenium_tests.yml
+++ b/roles/infrared-horizon-selenium/tasks/run_selenium_tests.yml
@@ -13,6 +13,7 @@
       - pytest
       - pytest-django
       - pytest-html
+      - Django==2.2.28
       - horizon
       - selenium==3.141.0
       - testtools


### PR DESCRIPTION
Add new dependency to use Django==2.2.28 since we are facing issue in unified job as plugin is failing with below error due to higher Django version 
`ImportError: cannot import name \'ugettext_lazy\' from \'django.utils.translation\`