### PR TITLE
Fix pytest to use earlier version due to failure

### DIFF
--- a/roles/infrared-horizon-selenium/tasks/run_selenium_tests.yml
+++ b/roles/infrared-horizon-selenium/tasks/run_selenium_tests.yml
@@ -10,7 +10,7 @@
 - name: Install python test dependencies in virtual environment
   pip:
     name:
-      - pytest
+      - pytest==7.3.2
       - pytest-django
       - pytest-html
       - Django==2.2.28


### PR DESCRIPTION
Horizon integration tests have been failing due to issue faced here : https://github.com/pytest-dev/pytest/issues/12263 . This patch pin pytest to use 7.3.2 version which works fine in our local .